### PR TITLE
Us 25 admin merchant show

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,4 +2,8 @@ class Admin::MerchantsController < ApplicationController
   def index
     @merchants = Merchant.all
   end
+
+  def show
+    @merchant = Merchant.find(params[:id])
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,4 +1,4 @@
-.20<h1>Admin: Merchants Index</h1>
+<h1>Admin: Merchants Index</h1>
 <% @merchants.each do |merchant|%>
-  <p><%= "Name: #{merchant.name}"%></p>
+  <p><%= link_to merchant.name, admin_merchant_path(merchant.id) %></p>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Merchant Show Page</h1>
+<h3><%= @merchant.name %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
 
   namespace :admin do
-    resources :merchants, only: :index
+    resources :merchants, only: [:index, :show]
   end
 
   get "/merchants/:id/dashboard", to: "merchants#show"

--- a/spec/features/admin/merchant/show_spec.rb
+++ b/spec/features/admin/merchant/show_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Admin Merchant Show Page" do 
+  it "a user can click on any Merchant in Admin Merchant Index to get taken to that Merchan'ts Show Page" do 
+    merchant = Merchant.create!({name: "Schroeder-Jerde"})
+
+    visit "/admin/merchants"
+
+    click_link merchant.name
+
+    expect(current_path).to eq("/admin/merchants/#{merchant.id}")
+    expect(page).to have_content("#{merchant.name}")
+  end
+
+end 


### PR DESCRIPTION
Implement user story #25. This pull request creates an admin merchant show page (/admin/merchant/:merchant_id).  Converts the admin merchants index page display of merchant names to links that, when clicked, redirect the user to that specific merchant's show page. With this commit, the show page is only a header with the name of the page and the merchant's name.