### PR TITLE
US 10 merchant items grouped by status

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -55,7 +55,6 @@ end
     if self.status == "enabled"
       return true
     end
-    
   end
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -51,6 +51,12 @@ end
   #     return false
   #   end
   # end
+  def enabled?
+    if self.status == "enabled"
+      return true
+    end
+    
+  end
 
 
   def toggle_status

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -2,8 +2,9 @@
 <h1>Items</h1>
 </div>
 
+  <section class="enabled-items">
+    <h2>Enabled Items:</h2>
 <% @items.each do |item| %>
-  <section class="enabled-items" id="<%= item.name %>">
     <h3>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>
@@ -12,8 +13,10 @@
     </h3>
   </section>
 <% end %>
+
+<h2>Disabled Items:</h2>
+  <section class="disabled-items">
 <% @items.each do |item| %>
-  <section class="disabled-items" id="<%= item.name %>">
     <h3>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -2,27 +2,31 @@
 <h1>Items</h1>
 </div>
 
-  <section class="enabled-items">
-    <h2>Enabled Items:</h2>
+  <section id="enabled-items">
+    <h2>Enabled Items</h2>
 <% @items.each do |item| %>
-    <h3>
+    <p>
+      <% if item.enabled? == true %>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>
         <%= submit_tag item.button_text %>
       <% end %>
-    </h3>
+      <% end %>
+    </p>
   </section>
 <% end %>
 
-<h2>Disabled Items:</h2>
-  <section class="disabled-items">
+<h2>Disabled Items</h2>
+  <section id="disabled-items">
 <% @items.each do |item| %>
-    <h3>
+    <p>
+      <% if item.enabled? != true %>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>
         <%= submit_tag item.button_text %>
       <% end %>
-    </h3>
+      <% end %>
+    </p>
   </section>
 <% end %>
 

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -3,7 +3,17 @@
 </div>
 
 <% @items.each do |item| %>
-  <section id="<%= item.name %>">
+  <section class="enabled-items" id="<%= item.name %>">
+    <h3>
+      <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
+      <%= form_with url: item_path(item), method: :patch do %>
+        <%= submit_tag item.button_text %>
+      <% end %>
+    </h3>
+  </section>
+<% end %>
+<% @items.each do |item| %>
+  <section class="disabled-items" id="<%= item.name %>">
     <h3>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -9,7 +9,7 @@
       <% if item.enabled? == true %>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>
-        <%= submit_tag item.button_text %>
+        <%= submit_tag item.button_text, id: "submit-#{item.id}" %>
       <% end %>
       <% end %>
     </p>
@@ -23,7 +23,7 @@
       <% if item.enabled? != true %>
       <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
       <%= form_with url: item_path(item), method: :patch do %>
-        <%= submit_tag item.button_text %>
+        <%= submit_tag item.button_text, id: "submit-#{item.id}" %>
       <% end %>
       <% end %>
     </p>

--- a/spec/features/admin/merchant/index_spec.rb
+++ b/spec/features/admin/merchant/index_spec.rb
@@ -23,21 +23,20 @@ RSpec.describe "Admin Merchants Index", type: feature do
       expect(page).to have_button("Disable")
       click_button "Disable"
     end
-
-    expect(page).to have_content("The status has been disabled")
     
+    expect(page).to have_content("The status has been disabled")
     within "#index-#{merchant.id}" do 
     expect(page).to_not have_link(merchant.name)
     expect(page).to have_button("Enable")
     click_button "Enable"
   end
   
-    expect(page).to have_content("The status has been enabled")
-
-    within "#index-#{merchant.id}" do
-      expect(page).to have_link(merchant.name)
-      expect(page).to have_button("Disable")
-    end
-  end
+  expect(page).to have_content("The status has been enabled")
   
+  within "#index-#{merchant.id}" do
+  expect(page).to have_link(merchant.name)
+  expect(page).to have_button("Disable")
+end
+end
+
 end 

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
   describe 'items grouped by status' do
     it 'has an enabled items and disabled items section ' do
       visit "merchants/#{@merchant1.id}/items"
-        expect(page).to have_selector('.enabled-items')
-        expect(page).to have_selector('.disabled-items')
+        expect(page).to have_content("Enabled Items")
+        expect(page).to have_content("Disabled Items")
     end
     it 'has items divided by section' do
       visit "/merchants/#{@merchant1.id}/items"
@@ -151,20 +151,19 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
     end
     it 'clicks the button to change the status section of the item' do
       visit "merchants/#{@merchant1.id}/items"
-      save_and_open_page
-      within('.disabled-items') do
-        expect(page).to have_content(@item1.name)
-      end
-      within('.enabled-items') do
-        expect(page).to_not have_content(@item1.name)
-      end
-      # click_button "Enable"
-      # within('.disabled-items') do
-      #   expect(page).to_not have_content(@item1.name)
-      # end
-      # within('.enabled-items') do
-      #   expect(page).to have_content(@item1.name)
-      # end
+      expect("Disabled Items").to appear_before(@item1.name)
+      
+      find_button("submit-#{@item1.id}").click
+      expect(@item1.name).to appear_before("Disabled Items")
+      
+      find_button("submit-#{@item2.id}").click
+      expect(@item2.name).to appear_before("Disabled Items")
+      
+      find_button("submit-#{@item3.id}").click
+      expect(@item3.name).to appear_before("Disabled Items")
+      
+      find_button("submit-#{@item1.id}").click
+      expect("Disabled Items").to appear_before(@item1.name)
     end
   end
       

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -31,13 +31,6 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
       unit_price: 4291,
       merchant_id: @merchant2.id
     )
-    # @item5 = Item.create!(
-    #   id: 5,
-    #   name: "Item Expedita Aliquam",
-    #   description: "Voluptate aut labore qui illum tempore eius. Corrupti cum et rerum. Enim illum labore voluptatem dicta consequatur. Consequatur sunt consequuntur ut officiis.",
-    #   unit_price: 68723,
-    #   merchant_id: @merchant2.id
-    # )
     @item5 = Item.create!(name: "Gold Ring", unit_price: 1200, merchant_id: @merchant1.id, description: "14k Gold")
     @item6 = Item.create!(name: "Silver Ring", unit_price: 900, merchant_id: @merchant1.id, description: "Pure Silver")
     @item7 = Item.create!(name: "Gold Necklace", unit_price: 1400, merchant_id: @merchant1.id, description: "10k Gold")
@@ -140,6 +133,14 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
 
     expect(page).to have_content(@item4.name)
     expect(page).to have_button("Disable")
+  end
+
+  describe 'items grouped by status' do
+    it 'has an enabled items and disabled items section ' do
+      visit "merchants/#{@merchant1.id}/items"
+        expect(page).to have_selector('.enabled-items')
+        expect(page).to have_selector('.disabled-items')
+    end
   end
 
   #User Story 12

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -142,25 +142,12 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
         expect(page).to have_selector('.disabled-items')
     end
     it 'has items divided by section' do
-      visit "merchants/#{@merchant1.id}/items"
-      within('.disabled-items') do
-        expect(page).to have_content(@item1.name)
-        expect(page).to have_content(@item2.name)
-        expect(page).to have_content(@item3.name)
-        expect(page).to have_content(@item5.name)
-        expect(page).to have_content(@item6.name)
-        expect(page).to have_content(@item7.name)
-        expect(page).to have_content(@item8.name)
-      end
-      within('.enabled-items') do
-        expect(page).to_not have_content(@item1.name)
-        expect(page).to_not have_content(@item2.name)
-        expect(page).to_not have_content(@item3.name)
-        expect(page).to_not have_content(@item5.name)
-        expect(page).to_not have_content(@item6.name)
-        expect(page).to_not have_content(@item7.name)
-        expect(page).to_not have_content(@item8.name)
-      end
+      visit "/merchants/#{@merchant1.id}/items"
+      expect("Enabled Items").to appear_before("Disabled Items")
+      expect("Disabled Items").to appear_before(@item1.name)
+      expect("Disabled Items").to appear_before(@item2.name)
+      expect("Disabled Items").to appear_before(@item3.name)
+      expect("Disabled Items").to appear_before(@item5.name)
     end
     it 'clicks the button to change the status section of the item' do
       visit "merchants/#{@merchant1.id}/items"

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -162,8 +162,25 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
         expect(page).to_not have_content(@item8.name)
       end
     end
+    it 'clicks the button to change the status section of the item' do
+      visit "merchants/#{@merchant1.id}/items"
+      save_and_open_page
+      within('.disabled-items') do
+        expect(page).to have_content(@item1.name)
+      end
+      within('.enabled-items') do
+        expect(page).to_not have_content(@item1.name)
+      end
+      # click_button "Enable"
+      # within('.disabled-items') do
+      #   expect(page).to_not have_content(@item1.name)
+      # end
+      # within('.enabled-items') do
+      #   expect(page).to have_content(@item1.name)
+      # end
+    end
   end
-
+      
   #User Story 12
   describe "Top 5 Most Popular Items" do
     describe "Displays the names of the top 5 most popular items ranked by revenue generated" do

--- a/spec/features/merchant/items/index_spec.rb
+++ b/spec/features/merchant/items/index_spec.rb
@@ -141,6 +141,27 @@ RSpec.describe "Merchant Items Index Page", type: :feature do
         expect(page).to have_selector('.enabled-items')
         expect(page).to have_selector('.disabled-items')
     end
+    it 'has items divided by section' do
+      visit "merchants/#{@merchant1.id}/items"
+      within('.disabled-items') do
+        expect(page).to have_content(@item1.name)
+        expect(page).to have_content(@item2.name)
+        expect(page).to have_content(@item3.name)
+        expect(page).to have_content(@item5.name)
+        expect(page).to have_content(@item6.name)
+        expect(page).to have_content(@item7.name)
+        expect(page).to have_content(@item8.name)
+      end
+      within('.enabled-items') do
+        expect(page).to_not have_content(@item1.name)
+        expect(page).to_not have_content(@item2.name)
+        expect(page).to_not have_content(@item3.name)
+        expect(page).to_not have_content(@item5.name)
+        expect(page).to_not have_content(@item6.name)
+        expect(page).to_not have_content(@item7.name)
+        expect(page).to_not have_content(@item8.name)
+      end
+    end
   end
 
   #User Story 12

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -144,5 +144,21 @@ RSpec.describe Item, type: :model do
       expect(best_day).to eq(Date.today)
     end
   end
+
+  describe "#enabled?" do
+    context "when item status is 'enabled'" do
+      it "returns true" do
+        item = Item.new(status: "enabled")
+        expect(item.enabled?).to eq(true)
+      end
+    end
+
+    context "when item status is not 'enabled'" do
+      it "returns nil" do
+        item = Item.new(status: "disabled")
+        expect(item.enabled?).to eq(nil)
+      end
+    end
+  end
 end
   


### PR DESCRIPTION
Added enabled and disabled sections in the merchant item index
New model method, enabled?, for item, also tested
I think that the capybara testing for the feature could be written more concisely, but this does work, including when I tried it out actually being able to see the page. 

There is one test related to a date that is not passing right now, but I think it might be due to time zones? Not really sure. Would be worth looking at tomorrow. 